### PR TITLE
Updated the configuration to use SWC and not Babel for faster performance 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,9 @@
 export default {
   transform: {
-    '^.+\\.js$': 'babel-jest',
+    "^.+\\.(js|jsx|ts|tsx)$": "@swc/jest",
   },
-  extensionsToTreatAsEsm: ['.js'],
+  extensionsToTreatAsEsm: [".ts", ".tsx", ".js", ".jsx"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
 };


### PR DESCRIPTION
This Pull request (PR) replaces Babel with SWC in the Jest testing environment to improve performance and reduce compilation time. The babel.config.js file has been removed, and Jest is now configured to use @swc/jest as the transformer for JavaScript and TypeScript files.

**Changes:**

- Configured Jest to use SWC for .js, .jsx, .ts, and .tsx files.

- Ensured proper handling of ESM imports and module resolution.

- Added support for resolving relative imports correctly in tests.

- Removed the Babel configuration file to complete the transition.

**Impact:**

- Faster test execution due to SWC’s optimized performance.
 
- Improved compatibility with ES modules.
 
- No reliance on Babel for test transformations.